### PR TITLE
Add code to load org-capture-templates on startup

### DIFF
--- a/config.org
+++ b/config.org
@@ -136,19 +136,19 @@ This only shows today's tasks in the agenda view by default:
 ** Org-capture
 *** Templates
 #+BEGIN_SRC emacs-lisp
-(setq org-capture-templates
-      '(
-        ("t" "Todo" entry (file+headline (lambda () (concat org-directory "/" "inbox.org")) "In-Process") "* TODO %? %^g")
-        ("w" "Work Log" entry (file+headline (lambda () (concat org-directory "/" "WorkLogs.org")) "On-Deck") "** %(create-org-link 1) %?")
-        ("d" "Daily Review" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Daily") "** %(create-org-link 1 \"Daily Review\") %?")
-        ("k" "Weekly Review" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Weekly") "** %(create-org-link 1 \"Weekly Review\") %?")
-        ("s" "Start of Week Check-In" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Weekly") "** %(create-org-link 1 \"Start of Week Check-In\") %?")
-        ("r" "Research Note" entry (file+headline (lambda () (concat org-directory "/" "ResearchNotes.org")) "In-Process") "** %(create-org-link nil) %?")
-        ("l" "Lessons Learned" entry (file+headline (lambda () (concat org-directory "/" "LessonsLearned.org")) "Drafts") "** %(create-org-link nil) %?")
-        ("m" "Meeting Minute" entry (file+headline (lambda () (concat org-directory "/" "MeetingMinutes.org")) "In-Process") "** %(create-org-link 1) %?")
-        ))
+(after! org
+  (setq org-capture-templates
+        '(
+          ("t" "Todo" entry (file+headline (lambda () (concat org-directory "/" "inbox.org")) "In-Process") "* TODO %? %^g")
+          ("w" "Work Log" entry (file+headline (lambda () (concat org-directory "/" "WorkLogs.org")) "On-Deck") "** %(create-org-link 1) %?")
+          ("d" "Daily Review" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Daily") "** %(create-org-link 1 \"Daily Review\") %?")
+          ("k" "Weekly Review" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Weekly") "** %(create-org-link 1 \"Weekly Review\") %?")
+          ("s" "Start of Week Check-In" entry (file+headline (lambda () (concat org-directory "/" "Personal_Reviews.org")) "Weekly") "** %(create-org-link 1 \"Start of Week Check-In\") %?")
+          ("r" "Research Note" entry (file+headline (lambda () (concat org-directory "/" "ResearchNotes.org")) "In-Process") "** %(create-org-link nil) %?")
+          ("l" "Lessons Learned" entry (file+headline (lambda () (concat org-directory "/" "LessonsLearned.org")) "Drafts") "** %(create-org-link nil) %?")
+          ("m" "Meeting Minute" entry (file+headline (lambda () (concat org-directory "/" "MeetingMinutes.org")) "In-Process") "** %(create-org-link 1) %?")
+          )))
 #+END_SRC
-
 ** To-do Lists
 *** Workflow States
 


### PR DESCRIPTION
I used the ``after!`` macro to load the templates on startup.